### PR TITLE
More default repo settings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,4 @@
+/* global module */
 module.exports = {
   extends: ['airbnb', 'plugin:prettier/recommended'],
   env: {
@@ -13,6 +14,8 @@ module.exports = {
     'no-return-assign': 'off',
     'no-param-reassign': 'off',
     'no-restricted-syntax': ['off', 'ForOfStatement'],
+    'no-unused-expressions': 'off',
+    'no-loop-func': 'off',
     'import/prefer-default-export': 'off', // contrary to Agoric standard
   },
 };

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# emacs
+*~
+
 # Logs
 logs
 *.log
@@ -29,14 +32,14 @@ bower_components
 # node-waf configuration
 .lock-wscript
 
-# Compiled binary addons (http://nodejs.org/api/addons.html)
+# Compiled binary addons (https://nodejs.org/api/addons.html)
 build/Release
 
 # Dependency directories
 node_modules/
 jspm_packages/
 
-# Typescript v1 declaration files
+# TypeScript v1 declaration files
 typings/
 
 # Optional npm cache directory
@@ -56,6 +59,11 @@ typings/
 
 # dotenv environment variables file
 .env
+
+# next.js build output
+.next
+
+.idea/
 
 # dist files
 /dist


### PR DESCRIPTION
More default repo settings:

Since our code is strict-only, there's nothing wrong with nested named function declarations.

A tagged template literal expression statement (e.g., my "insist" tag currently in ERTP) is not a useless expression, and should not generate a lint warning.

Emacs leaves behind "*~" backup files as editing debris that we should ignore.