### PR TITLE
add optional jessie linting

### DIFF
--- a/.eslintrc-jessie.js
+++ b/.eslintrc-jessie.js
@@ -1,0 +1,7 @@
+/* global module */
+module.exports = {
+  extends: "jessie",
+  env: {
+    es6: true, // supports new ES6 globals (e.g., new types such as Set)
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,23 @@
+{
+  "name": "???",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "eslint-config-jessie": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-jessie/-/eslint-config-jessie-0.0.3.tgz",
+      "integrity": "sha512-L1JpgIZ+mXfKjTnVSykEknxvPHo14JHlkjfxmHBfCiOtF4CWq0H4EB1fUoxldjP1x87xZu0c0+WPqyqbvnFVxA==",
+      "dev": true,
+      "requires": {
+        "requireindex": "^1.2.0"
+      }
+    },
+    "requireindex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,19 +8,22 @@
   "scripts": {
     "test": "tape -r esm 'test/**/*.js'",
     "lint-fix": "eslint --fix '**/*.{js,jsx}'",
-    "lint-check": "eslint '**/*.{js,jsx}'"
+    "lint-check": "eslint '**/*.{js,jsx}'",
+    "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.{js,jsx}'",
+    "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.{js,jsx}'"
   },
   "devDependencies": {
     "eslint": "^5.11.1",
     "eslint-config-airbnb": "^17.1.0",
+    "eslint-config-jessie": "0.0.3",
     "eslint-config-prettier": "^3.3.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "^7.12.0",
     "prettier": "^1.16.4",
-    "tape": "^4.9.2",
     "tap-spec": "^5.0.0",
+    "tape": "^4.9.2",
     "tape-promise": "^4.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
This just installs eslint-config-jessie and adds an npm command to run jessie linting when desired. Note that eslint-config-jessie doesn't include all of the Jessie rules yet.