### PR TITLE
Test unexpected exception

### DIFF
--- a/test/sample-test.js
+++ b/test/sample-test.js
@@ -5,8 +5,7 @@ test('unique test description', async t => {
     t.true('various tests');
     t.equal(await Promise.resolve(123), 123);
   } catch (e) {
-    console.log('unexpected exception', e);
-    t.assert(false, e);
+    t.isNot(e, e, 'unexpected exception');
   } finally {
     t.end();
   }

--- a/test/sample-test.js
+++ b/test/sample-test.js
@@ -1,6 +1,7 @@
 import { test } from 'tape-promise/tape';
 
-test('unique test description', async t => {
+// TODO: remove .only when you have this test working
+test.only('unique test description', async t => {
   try {
     t.true('various tests');
     t.equal(await Promise.resolve(123), 123);


### PR DESCRIPTION
Cleanup to avoid ambient console.log when printing out an unexpected exception.  This writes the complete stack trace directly in the tap output.

Also, use `test.only()` as a best practice for writing new tests.
