### PR TITLE
switch to airbnb-base rather than airbnb w/ react

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 /* global module */
 module.exports = {
-  extends: ['airbnb', 'plugin:prettier/recommended'],
+  extends: ['airbnb-base', 'plugin:prettier/recommended'],
   env: {
     es6: true, // supports new ES6 globals (e.g., new types such as Set)
   },

--- a/package.json
+++ b/package.json
@@ -13,17 +13,15 @@
     "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.{js,jsx}'"
   },
   "devDependencies": {
-    "eslint": "^5.11.1",
-    "eslint-config-airbnb": "^17.1.0",
+    "eslint": "^6.1.0",
+    "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-jessie": "0.0.3",
-    "eslint-config-prettier": "^3.3.0",
-    "eslint-plugin-import": "^2.14.0",
-    "eslint-plugin-jsx-a11y": "^6.1.2",
-    "eslint-plugin-prettier": "^3.0.1",
-    "eslint-plugin-react": "^7.12.0",
-    "prettier": "^1.16.4",
+    "eslint-config-prettier": "^6.0.0",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-prettier": "^3.1.0",
+    "prettier": "^1.18.2",
     "tap-spec": "^5.0.0",
-    "tape": "^4.9.2",
+    "tape": "^4.11.0",
     "tape-promise": "^4.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Most of our repositories will not be using react, so let's switch to the Airbnb ESLint settings that do not include react (airbnb-base). 