### PR TITLE
loosen eslint rules a bit

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,12 +10,16 @@ module.exports = {
     'arrow-parens': 'off',
     strict: 'off',
     'no-console': 'off',
-    'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    'no-unused-vars': ['error', {
+      argsIgnorePattern: '^_',
+      varsIgnorePattern: '^_'
+    }],
     'no-return-assign': 'off',
     'no-param-reassign': 'off',
     'no-restricted-syntax': ['off', 'ForOfStatement'],
     'no-unused-expressions': 'off',
     'no-loop-func': 'off',
+    'no-inner-declarations': 'off',
     'import/prefer-default-export': 'off', // contrary to Agoric standard
   },
 };


### PR DESCRIPTION
The rule against inner declarations made sense for sloppy mode. In strict mode, aside from `var`, all declarations are lexically scoped. Inner declarations should be encouraged, not discouraged.

Variables like `_foo` that are used only one should be acceptable in general, not just in argument position.